### PR TITLE
We no longer need --asert=plain on 3.5+

### DIFF
--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -2,16 +2,6 @@
 set -e
 set -x
 
-# If we're running under Python 3.5, we can't use anything but --asert=plain
-if [[ $TOXENV = "py35" ]]; then
-    export TOXARGS="--assert=plain"
-fi
-
-# If we're running under Python 3.6, we can't use anything but --asert=plain
-if [[ $TOXENV = "py36" ]]; then
-    export TOXARGS="--assert=plain"
-fi
-
 # We want to create the virtual environment here, but not actually run anything
 tox --notest
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,7 +62,7 @@ def tmpdir(request):
     # directory while running the tests.
     request.addfinalizer(lambda: shutil.rmtree(str(tmp), ignore_errors=True))
 
-    return Path(str(tmp))
+    return Path(os.path.realpath(str(tmp)))
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
This was automatically migrated from pypa/pip#3115 to reparent it to the ``master`` branch. Please see original pull request for any previous discussion.

Original Submitter: @dstufft

---
Small Test.